### PR TITLE
initialization event streams after restart

### DIFF
--- a/server/src/v1/infrastructure/websockets/marketplaces/binance/binance-event-stream.class.ts
+++ b/server/src/v1/infrastructure/websockets/marketplaces/binance/binance-event-stream.class.ts
@@ -53,7 +53,7 @@ export class BinanceEventStream implements ITokenEventStream {
 
 	public stalk(symbol: string): void {
 		if (this.client.readyState !== this.client.OPEN) {
-			this._logger.debug(`WebSocket not open yet. Queuing ${symbol}...`);
+			this._logger.info(`WebSocket not open yet. Queuing ${symbol}...`);
 			this._pendingSymbols.push(symbol);
 			return;
 		}

--- a/server/src/v1/presentation/config/server.config.ts
+++ b/server/src/v1/presentation/config/server.config.ts
@@ -12,6 +12,7 @@ import { IMongoDbConfig } from "#infrastructure/database/mongodb/config/mongo.co
 import { errorMiddleware } from "#presentation/middlewares/errors/error.middleware.js";
 import { Logger } from "#utils/logger.js";
 
+
 export interface IServerConfig {
 	start(): Promise<void>;
 }
@@ -27,8 +28,7 @@ export class ServerConfig implements IServerConfig {
 		@inject(TYPES.ConfigService)
 		private readonly _config: ConfigService,
 		@inject(TYPES.MongoDbConfig)
-		private readonly _mongo: IMongoDbConfig,
-
+		private readonly _mongo: IMongoDbConfig
 	) {
 		this._server = new InversifyExpressServer(container, null, { rootPath: "/api/v1" });
 		this._baseUrl = this._config.get(EnvVariables.DOMAIN_URL);
@@ -43,6 +43,8 @@ export class ServerConfig implements IServerConfig {
 
 		app.listen(this._PORT);
 		this._logger.info(`Server is running on PORT: ${this._PORT}`);
+
+		await this._mongo.initEventStreams();
 	}
 
 	private initMiddlewares() {


### PR DESCRIPTION
🔄 Initialize Event Streams on Application Reboot
📌 Description

This PR introduces a new method initEventStreams() responsible for initializing all active event streams (tokens and NFTs) after the application restarts.

✅ What's Included

- Added initEventStreams() function to load subscriptions from the database.
- Filters subscriptions by target.type (token and nft).
-  Gracefully handles partial failures using Promise.allSettled. 
- Automatically resumes streaming logic for previously active subscriptions.